### PR TITLE
Fix admin user password change API path/payload mismatch

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -284,9 +284,9 @@ export default function UsersPage() {
     setError('')
 
     try {
-      await apiPatch(`/api/users/${editingUser.id}/password`, {
+      await apiPatch(`/api/users/${editingUser.id}`, {
         oldPassword: isOwnAccount ? passwordData.oldPassword : undefined,
-        newPassword: passwordData.password,
+        password: passwordData.password,
       })
       setShowPasswordModal(false)
     } catch (err) {


### PR DESCRIPTION
## Summary
This fixes admin user password changes from `/admin/users` failing with `Request failed`.

## Root Cause
The frontend was calling a non-existent route and wrong payload key:
- Called: `PATCH /api/users/:id/password`
- Sent key: `newPassword`

But backend implements:
- Route: `PATCH /api/users/:id`
- Password key: `password`

## Changes
- In `src/app/admin/users/page.tsx`:
  - changed endpoint to `/api/users/${editingUser.id}`
  - changed payload key from `newPassword` to `password`

## Verification
- Previously observed in logs: `PATCH /api/users/<id>/password` returned `404`
- Endpoint sanity check:
  - `PATCH /api/users/test/password` -> `404`
  - `PATCH /api/users/test` -> `401` (route exists, auth required)

Fixes #36
