### PR TITLE
CodeQL: scan python and actions alongside javascript-typescript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,11 +10,16 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (javascript-typescript)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python, actions]
 
     steps:
       - name: Checkout repository
@@ -23,10 +28,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:javascript-typescript"
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

CodeQL has been running reliably on this repo (last analysis 2026-07-29, weekly cron every Monday), but it only ever analysed `javascript-typescript`.

GitHub's language detection for this repo reports `actions`, `javascript`, `javascript-typescript`, `python`, and `typescript`. That leaves two things unscanned:

- `src/worker/external-notifications/apprise-runner.py`
- all seven files in `.github/workflows/`

The `actions` pack is not hypothetical — it's what surfaced a `actions/missing-workflow-permissions` alert in `kopage-docker`, and this repo has considerably more workflow surface.

## Change

Converts the single job into a matrix over `javascript-typescript`, `python`, and `actions`. Each language gets its own analysis and its own SARIF `category`, which is what keeps the three result sets from overwriting each other in the Security tab.

`fail-fast: false` so one language failing doesn't cancel the others' uploads. Triggers, `security-extended` suite, and action versions are unchanged.

## Notes

Expect the first run to open some `actions` alerts — most likely missing top-level `permissions:` blocks on the workflows that don't declare them.