### PR TITLE
Pin docker actions to commit SHAs

### DIFF
--- a/.github/workflows/test-dev-clean-install.yml
+++ b/.github/workflows/test-dev-clean-install.yml
@@ -29,10 +29,10 @@ jobs:
           echo "redis_version=$REDIS_IMAGE" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build image from source
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true

--- a/.github/workflows/test-dev-upgrade.yml
+++ b/.github/workflows/test-dev-upgrade.yml
@@ -30,10 +30,10 @@ jobs:
           echo "from_version=$FROM_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build target image from source
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true


### PR DESCRIPTION
Clears the four `actions/unpinned-tag` alerts that CodeQL's `actions` pack raised on `main` after #82.

## Alerts

```
[medium] actions/unpinned-tag — .github/workflows/test-dev-clean-install.yml:32, :35
[medium] actions/unpinned-tag — .github/workflows/test-dev-upgrade.yml:33, :36
```

Both dev test workflows referenced `docker/setup-buildx-action@v4` and `docker/build-push-action@v7` by mutable major tag. Those tags are moved by the upstream maintainers, so what actually runs in CI can change without any commit here — and these two workflows build the image from source and run it, so a compromised or simply changed action has real reach.

## Change

| Action | Was | Now |
|---|---|---|
| `docker/setup-buildx-action` | `v4` | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` (v4.2.0) |
| `docker/build-push-action` | `v7` | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` (v7.3.0) |

I verified each SHA is exactly what the major tag resolves to right now — `v4` and `v4.2.0` point at the same commit, likewise `v7` and `v7.3.0` — so this pins the version already running and changes no behaviour. The version stays in a trailing comment so the file is still readable, and Dependabot understands that format for future bumps.

`actions/checkout`, `actions/upload-artifact`, and `github/codeql-action` are not flagged and are left alone — the rule exempts GitHub-owned actions.